### PR TITLE
Compare modlist hash when joining lobby

### DIFF
--- a/logmodlist.cs
+++ b/logmodlist.cs
@@ -1,6 +1,7 @@
 ﻿using BepInEx;
 using BepInEx.Bootstrap;
 using BepInEx.Logging;
+using BepInEx.Configuration;
 using HarmonyLib;
 using System;
 using System.Reflection;
@@ -28,6 +29,7 @@ namespace logmodlist
             logmodlist.instance = this;
             logmodlist.Log = base.Logger;
             logmodlist.Log.LogInfo((object)"logmodlist loaded...");
+            ConfigManager.Init(Config);
             Harmony.CreateAndPatchAll(Assembly.GetExecutingAssembly());
         }
 

--- a/startPatch.cs
+++ b/startPatch.cs
@@ -9,19 +9,23 @@ using System.Linq;
 
 namespace logmodlist
 {
-    [HarmonyPatch(typeof(GameNetworkManager), "Awake")]
+    [HarmonyPatch(typeof(GameNetworkManager))]
     public class startPatch : MonoBehaviour
     {
         private static Dictionary<string, PluginInfo> PluginsLoaded = new Dictionary<string, PluginInfo>();
+        public static string generatedHash = "";
 
+        [HarmonyPatch("Awake")]
+        [HarmonyPostfix]
         static void Postfix()
         {
             logmodlist.Log.LogInfo("Creating Modlist Hash.");
             PluginsLoaded = Chainloader.PluginInfos;
-            string ModListHash = DictionaryHashGenerator.GenerateHash(PluginsLoaded);
+            generatedHash = DictionaryHashGenerator.GenerateHash(PluginsLoaded);
+
             logmodlist.Log.LogInfo("\t==========================");
             logmodlist.Log.LogInfo("\t");
-            logmodlist.Log.LogInfo($"Modlist Hash: {ModListHash}");
+            logmodlist.Log.LogInfo($"Modlist Hash: {generatedHash}");
             logmodlist.Log.LogInfo("\t");
             logmodlist.Log.LogInfo("\t==========================");
             // Log dictionary contents

--- a/startPatch.cs
+++ b/startPatch.cs
@@ -45,8 +45,7 @@ namespace logmodlist
             PluginsLoaded = Chainloader.PluginInfos;
             generatedHash = DictionaryHashGenerator.GenerateHash(PluginsLoaded);
 
-            logmodlist.Log.LogInfo("\t==========================");
-            logmodlist.Log.LogInfo("\t");
+            logmodlist.Log.LogInfo("==========================");
             logmodlist.Log.LogInfo($"Modlist Hash: {generatedHash}");
 
             if (ConfigManager.ExpectedModListHash.Value != "")
@@ -78,6 +77,8 @@ namespace logmodlist
             {
                 logmodlist.Log.LogInfo($"{entry.Key}: {entry.Value}");
             }
+
+            logmodlist.Log.LogInfo("==========================");
         }
     }
 

--- a/startPatch.cs
+++ b/startPatch.cs
@@ -54,13 +54,12 @@ namespace logmodlist
             lobby.SetData("ModListHash", DictionaryHashGenerator.GenerateHash(Chainloader.PluginInfos));
             logmodlist.Log.LogInfo($"Setting lobby ModHashList to {startPatch.generatedHash}");
         }
-
-
     }
 
     [HarmonyPatch(typeof(GameNetworkManager))]
     public class LobbyJoinPatch
     {
+
         [HarmonyPatch("StartClient")]
         [HarmonyPostfix]
         static void Postfix(SteamId id)
@@ -70,7 +69,7 @@ namespace logmodlist
             var lobbyModList = GameNetworkManager.Instance.currentLobby?.GetData("ModListHash");
             if (lobbyModList == null)
             {
-                logmodlist.Log.LogInfo("Host does not have a modlist hash.");
+                logmodlist.Log.LogWarning("Host does not have a modlist hash.");
                 return;
             }
             else


### PR DESCRIPTION
My proposition implements:
- creating LobbyData tag with host's modlist hash
- client-side comparison of said tag when joining lobbies
- config file with ExpectedHashValue setting (compared at startup)