### PR TITLE
Make hash effectively read only to other mods

### DIFF
--- a/startPatch.cs
+++ b/startPatch.cs
@@ -56,7 +56,7 @@ namespace logmodlist
     public class startPatch : MonoBehaviour
     {
         private static Dictionary<string, PluginInfo> PluginsLoaded = new Dictionary<string, PluginInfo>();
-        public static string generatedHash = "";
+        public static string generatedHash { get; internal set; } = "";
 
         [HarmonyPatch("Awake")]
         [HarmonyPostfix]


### PR DESCRIPTION
Allow other mods to read hash, but move it to private set to keep it slightly more 'secure' from writing (easily bypassed by Harmony ig so ehhhhh).